### PR TITLE
fix: don't emit markdown in annotations

### DIFF
--- a/lib/jq.sh
+++ b/lib/jq.sh
@@ -6,7 +6,7 @@
 function json_to_annotation() {
   # note: assumes input is piped
   jq -r '.[] | (select(.level == ("info", "style")) .level |= "notice") |
-         "::\(.level) file=\(.file),line=\(.line),col=\(.column)::\(.message) ([\(.code)](https://github.com/hadolint/hadolint/wiki/\(.code)))"'
+         "::\(.level) file=\(.file),line=\(.line),col=\(.column)::\(.message) (\(.code))"'
 }
 
 function exit_if_found_in_json() {

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -50,8 +50,8 @@ function test_output_hadolint_version() {
 function test_json_to_annotation() {
   local RES=""
   RES=$(echo "${HADOLINT_JSON_RESPONSE}" | json_to_annotation)
-  assert_equals "${RES}" '::error file=Dockerfile,line=2,col=1::MAINTAINER is deprecated ([DL4000](https://github.com/hadolint/hadolint/wiki/DL4000))
-::warning file=Dockerfile,line=9,col=1::Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>` ([DL3018](https://github.com/hadolint/hadolint/wiki/DL3018))'
+  assert_equals "${RES}" '::error file=Dockerfile,line=2,col=1::MAINTAINER is deprecated (DL4000)
+::warning file=Dockerfile,line=9,col=1::Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>` (DL3018)'
 }
 
 function test_exit_if_found_in_json() {


### PR DESCRIPTION
Only plaintext is supported.