### PR TITLE
doc: fix missing link to hadolint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ Also known as "can I run this in production". The action itself is tested via CI
 ## Performance
 
 Due to staying with bash we can avoid Docker-related performance penalties. Yet to be benchmarked, but it is likely on par or faster than other hadolint actions.
+
+[hadolint]: http://github.com/hadolint/hadolint/


### PR DESCRIPTION
The readme contained a reference to a link, but the link was nowhere to be found.

Spotted by @chuma9615.