### PR TITLE
test/e2e: make test executable

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash_unit
 
 HL="../hadolint.sh"
 


### PR DESCRIPTION
We can now invoke it directly if `bash_unit` is installed:
```bash
$ test/e2e.sh
Running tests in test/e2e.sh
Running test_annotate... SUCCESS ✓
Running test_custom_config... SUCCESS ✓
Running test_custom_output_format... SUCCESS ✓
Running test_custom_path... SUCCESS ✓
Running test_default_path... SUCCESS ✓
Running test_default_path_with_dockerfile... SUCCESS ✓
Running test_disable_annotate... SUCCESS ✓
Running test_output_with_nonzero_exit... SUCCESS ✓
Running test_override_errorlevel... SUCCESS ✓
Running test_version_output... SUCCESS ✓
```