### PR TITLE
main: error check against json array

### DIFF
--- a/lib/main.sh
+++ b/lib/main.sh
@@ -58,8 +58,8 @@ function run() {
   [[ "${ERRORLEVEL}" == "1" ]] && echo "${OUTPUT}" | exit_if_found_in_json "warning"
   [[ "${ERRORLEVEL}" == "1" ]] && echo "${OUTPUT}" | exit_if_found_in_json "error"
   
-  # Any output would imply an error
-  [[ "${ERRORLEVEL}" == "2" && "${OUTPUT}" != "" ]] && exit 1
+  # An empty json array would imply an error
+  [[ "${ERRORLEVEL}" == "2" && "${OUTPUT}" != "[]" ]] && exit 1
   
   # You either did well or chose to become a better person
   exit 0

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -35,6 +35,7 @@ test_override_errorlevel() {
   assert "error_level=-1 dockerfile=fixtures/Dockerfile-error ${HL}"
   assert_fail "dockerfile=fixtures/Dockerfile-error ${HL}"
   assert_fail "error_level=2 dockerfile=fixtures/Dockerfile-error ${HL}"
+  assert "error_level=2 dockerfile=fixtures/Dockerfile-valid ${HL}"
   assert "dockerfile=fixtures/Dockerfile-warning ${HL}"
   assert_fail "error_level=1 dockerfile=fixtures/Dockerfile-warning ${HL}"
 }

--- a/test/fixtures/Dockerfile-valid
+++ b/test/fixtures/Dockerfile-valid
@@ -1,0 +1,3 @@
+FROM alpine:3.12
+
+RUN ls


### PR DESCRIPTION
If `error_level` is set to 2, any output from hadolint should be seen as an error. Since hadolint emits an array when output is set to json, this is seen as our happy path.

Fixes: https://github.com/jbergstroem/hadolint-gh-action/issues/24