### PR TITLE
Support Sonarqube as output formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ jobs:
 
 ## Parameters
 
-| Variable      | Default        | Description                                                                                           |
-| :------------ | :------------- | :---------------------------------------------------------------------------------------------------- |
-| dockerfile    | `./Dockerfile` | Path to Dockerfile(s). Accepts shell expansions (`**/Dockerfile`)                                     |
-| config_file   |                | Path to optional config (hadolint defaults to read `./hadolint.yml` if it exists)                     |
-| error_level   | `0`            | Fail CI if hadolint emits output (`-1`: never, `0`: error, `1`: warning, `2`: info)                   |
-| annotate      | true           | Annotate code inline in the github PR viewer (`true`/`false`)                                         |
-| output_format |                | Set output format (choose between `tty`, `json`, `checkstyle`, `codeclimate` or `gitlab_codeclimate`) |
-| hadolint_path |                | Absolute path to hadolint binary. If unset, it is assumed to exist in `$PATH`                         |
+| Variable      | Default        | Description                                                                                                        |
+| :------------ | :------------- | :----------------------------------------------------------------------------------------------------------------- |
+| dockerfile    | `./Dockerfile` | Path to Dockerfile(s). Accepts shell expansions (`**/Dockerfile`)                                                  |
+| config_file   |                | Path to optional config (hadolint defaults to read `./hadolint.yml` if it exists)                                  |
+| error_level   | `0`            | Fail CI if hadolint emits output (`-1`: never, `0`: error, `1`: warning, `2`: info)                                |
+| annotate      | true           | Annotate code inline in the github PR viewer (`true`/`false`)                                                      |
+| output_format |                | Set output format (choose between `tty`, `json`, `checkstyle`, `codeclimate`, `gitlab_codeclimate` or `sonarqube`) |
+| hadolint_path |                | Absolute path to hadolint binary. If unset, it is assumed to exist in `$PATH`                                      |
 
 ## Hadolint version
 

--- a/lib/validate.sh
+++ b/lib/validate.sh
@@ -12,7 +12,7 @@ function validate_annotate() {
 }
 
 function validate_output_format() {
-  local -a output_formats=(tty json checkstyle codeclimate gitlab_codeclimate)
+  local -a output_formats=(tty json checkstyle codeclimate gitlab_codeclimate sonarqube)
   for format in "${output_formats[@]}"; do
     [[ "${format}" == "${1}" ]] && return 0
   done

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -32,6 +32,7 @@ test_validate_invalid_annotate() {
 test_validate_output_format() {
   assert "validate_output_format gitlab_codeclimate"
   assert "validate_output_format tty"
+  assert "validate_output_format sonarqube"
 }
 
 test_validate_invalid_output_format() {


### PR DESCRIPTION
In Hadolint `2.5.0` the sonarqube formatter was added. This allows us to output it as part of running CI.