### PR TITLE
fix: tell shellcheck where to find source file

### DIFF
--- a/hadolint.sh
+++ b/hadolint.sh
@@ -5,13 +5,13 @@ set -euo pipefail
 
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-# shellcheck disable=SC1090 # this is intentional
-. "${DIR}/lib/hadolint.sh"
-# shellcheck disable=SC1090 # this is intentional
-. "${DIR}/lib/main.sh"
-# shellcheck disable=SC1090 # this is intentional
-. "${DIR}/lib/jq.sh"
-# shellcheck disable=SC1090 # this is intentional
-. "${DIR}/lib/validate.sh"
+# shellcheck source=lib/hadolint.sh
+. "${DIR}"/lib/hadolint.sh
+# shellcheck source=lib/main.sh
+. "${DIR}"/lib/main.sh
+# shellcheck source=lib/jq.sh
+. "${DIR}"/lib/jq.sh
+# shellcheck source=lib/validate.sh
+. "${DIR}"/lib/validate.sh
 
 run


### PR DESCRIPTION
No need to disable the code analyzer since we can tell it where to look. In addition to this, you need to tell shellcheck to follow includes by passing `-x` in commandline or passing all source files.