### PR TITLE
fix: typo in action test

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: jbergstroem/checkout@$master
+      - uses: jbergstroem/checkout@master
         with:
           dockerfile: test/fixtures/Dockerfile-valid


### PR DESCRIPTION
A dollar sign snuck in, making the point that not being able to dynamically test actions as part of a PR flow leads to errors.