### PR TITLE
chore: update to a newer github actions vm

### DIFF
--- a/.github/workflows/lint-actionlint.yml
+++ b/.github/workflows/lint-actionlint.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   actionlint:
     name: actionlint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.0.2
       - name: Install Actionlint

--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   prettier:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: prettier
     steps:
       - uses: actions/checkout@v3.0.2

--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: shellcheck
     env:
       SHELLCHECK_VERSION: 0.8.0

--- a/.github/workflows/lint-shfmt.yml
+++ b/.github/workflows/lint-shfmt.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   shfmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: shfmt
     env:
       SHFMT_VERSION: 3.5.0

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   hadolint-gh-action:
     name: action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.0.2
       - uses: jbergstroem/hadolint-gh-action@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   bash_unit:
     name: bash_unit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.0.2
       - name: fetch hadolint version

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ on: pull_request
 
 jobs:
   hadolint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: "Hadolint"
     steps:
       - uses: actions/checkout@v2

--- a/USAGE.md
+++ b/USAGE.md
@@ -15,7 +15,7 @@ on: pull_request
 
 jobs:
   hadolint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: "Hadolint"
     steps:
       - uses: actions/checkout@v2
@@ -50,7 +50,7 @@ on:
 
 jobs:
   hadolint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: "Hadolint"
     steps:
       - uses: actions/checkout@v2
@@ -78,7 +78,7 @@ on: pull_request
 
 jobs:
   hadolint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: "Hadolint"
     steps:
       - uses: actions/checkout@v2
@@ -101,7 +101,7 @@ on: pull_request
 
 jobs:
   hadolint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: "Hadolint"
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Mostly to stay current and the potential upside of bash `5.0` -> `5.1`.