### PR TITLE
chore: update lint dependencies

### DIFF
--- a/.github/workflows/lint-actionlint.yml
+++ b/.github/workflows/lint-actionlint.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
       - name: Install Actionlint
         env:
-          ACTIONLINT_VERSION: 1.6.13
+          ACTIONLINT_VERSION: 1.6.18
         run: |
           wget -q -O- "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | tar -x -z -C . actionlint && \
           mv actionlint /usr/local/bin

--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
       - uses: actions/setup-node@v3.4.1
         with:
-          node-version: 16
+          node-version: 18
       - name: install prettier
         run: npm install -g prettier
       - name: run prettier

--- a/.github/workflows/lint-shfmt.yml
+++ b/.github/workflows/lint-shfmt.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: shfmt
     env:
-      SHFMT_VERSION: 3.5.0
+      SHFMT_VERSION: 3.5.1
     steps:
       - uses: actions/checkout@v3.0.2
       - name: install shfmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           sudo mv hadolint /usr/local/bin/hadolint
       - name: install bash_unit
         env:
-          BASH_UNIT_VERSION: 1.9.1
+          BASH_UNIT_VERSION: 2.0.0
         run: |
           wget -q -O- https://github.com/pgrange/bash_unit/archive/refs/tags/v${{ env.BASH_UNIT_VERSION }}.tar.gz | tar xz --strip=1 -C . && \
           sudo mv bash_unit /usr/local/bin


### PR DESCRIPTION
- bash_unit `2.0.0`
- shfmt `3.5.1`
- actionlint `1.3.18`

Additionally, invoke prettier (which always uses latest) via Node 18.