### PR TITLE
feat: refactor tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,8 @@
     {
       "fileMatch": ["^\\.github/workflows/[^/]+\\.yml$"],
       "matchStrings": [
-        "version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls \"https://github.com/(?<depName>.*?)/releases/download.*"
+        "version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls \"https://github.com/(?<depName>.*?)/releases/download.*",
+        "https://github\\.com/(?<depName>.*?)/archive/refs/tags/(?<currentValue>.*?)\\.tar\\.gz"
       ],
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,9 @@
-name: lint
+name: Lint
 on:
   pull_request:
     paths:
       # actionlint
       - ".github/workflows/*.yml"
-      # renovate
-      - ".github/renovate.json"
       # prettier
       - "**.md"
       - "**.yml"
@@ -62,16 +60,13 @@ jobs:
           echo "::add-matcher::.github/matcher-shellcheck.json"
           shellcheck -f gcc -S warning hadolint.sh lib/*.sh test/*.sh
   shfmt:
-    name: shfmt
+    name: Shfmt
     runs-on: ubuntu-22.04
-    env:
-      SHFMT_VERSION: 3.5.1
     steps:
       - uses: actions/checkout@v3.1.0
-      - name: install shfmt
-        run: |
-          wget -q -O shfmt "https://github.com/mvdan/sh/releases/download/v${{ env.SHFMT_VERSION }}/shfmt_v${{ env.SHFMT_VERSION }}_linux_amd64" && \
-          chmod +x shfmt && \
-          sudo mv shfmt /usr/local/bin/
-      - name: lint shell scripts
+      - name: Install shfmt
+        env:
+          version: "3.5.1"
+        run: curl -L -s -o shfmt "https://github.com/mvdan/sh/releases/download/v${{ env.version }}/shfmt_v${{ env.version }}_linux_amd64" && chmod +x shfmt && sudo mv shfmt /usr/local/bin
+      - name: Lint shell scripts
         run: shfmt -i 2 -d hadolint.sh lib/*.sh test/*.sh

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,0 +1,42 @@
+name: Test-E2E
+on:
+  pull_request:
+    paths:
+      - "**.sh"
+      - "test/**"
+      - "action.yml"
+      - ".github/workflows/test.yml"
+
+jobs:
+  gh-action-default:
+    name: Action validates dockerfiles
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: ./
+        with:
+          dockerfile: test/fixtures/Dockerfile-valid
+  gh-action-version:
+    name: Action supports custom version
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: ./
+        id: check
+        with:
+          dockerfile: test/fixtures/Dockerfile-valid
+          version: 2.9.0
+      - name: check hadolint version
+        run: |
+          if [[ ! "${{ steps.check.outputs.hadolint_version }}" == "2.9.0-no-git" ]]; then
+            echo "::error::Version mismatch: \"${{ steps.check.outputs.hadolint_version }}\" does not equal \"2.9.0-no-git\""
+            exit 1
+          fi
+  gh-action-glob:
+    name: Action supports glob expansion
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: ./
+        with:
+          dockerfile: "test/**/Dockerfile-glob-*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 on:
   pull_request:
     paths:
@@ -9,62 +9,22 @@ on:
 
 jobs:
   bash_unit:
-    name: bash tests
+    name: Bash unit tests
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.1.0
-      - name: install hadolint
+      - name: Get Hadolint version
         # yq is like jq for yaml
         # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#tools
+        # shellcheck disable=SC2034
+        run: echo version="$(yq .inputs.version.default action.yml)" >> "${GITHUB_ENV}"
+      - name: Install Hadolint
         run: |
-          version="$(yq .inputs.version.default action.yml)" && \
-          echo "::debug::Downloading Hadolint ${{ env.version }}" && \
-          wget -q -O hadolint "https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Linux-x86_64" && \
-          chmod +x hadolint && \
+          echo "::debug::Downloading Hadolint ${{ env.version }}"
+          curl -L -s -o hadolint "https://github.com/hadolint/hadolint/releases/download/v${{ env.version }}/hadolint-Linux-x86_64"
+          chmod +x hadolint
           sudo mv hadolint /usr/local/bin/hadolint
-      - name: install bash_unit
-        env:
-          BASH_UNIT_VERSION: 2.0.0
-        run: |
-          wget -q -O- https://github.com/pgrange/bash_unit/archive/refs/tags/v${{ env.BASH_UNIT_VERSION }}.tar.gz | tar xz --strip=1 -C . && \
-          sudo mv bash_unit /usr/local/bin
-      - name: output versions
-        run: |
-          hadolint --version
-          bash_unit -v
-      - name: run suite
+      - name: Install bash_unit
+        run: curl -Ls "https://github.com/pgrange/bash_unit/archive/refs/tags/v2.0.1.tar.gz" | tar -x -z --wildcards --strip-components=1 -C /usr/local/bin "*/bash_unit"
+      - name: Run suite
         run: bash_unit test/*.sh
-  gh-action-default:
-    name: action validates dockerfiles
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: ./
-        with:
-          dockerfile: test/fixtures/Dockerfile-valid
-  gh-action-version:
-    name: action supports custom version
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: ./
-        id: check
-        with:
-          dockerfile: test/fixtures/Dockerfile-valid
-          version: 2.9.0
-      - name: check hadolint version
-        run: |
-          if [[ ! "${{ steps.check.outputs.hadolint_version }}" == "2.9.0-no-git" ]]; then
-            echo "::error::Version mismatch: \"${{ steps.check.outputs.hadolint_version }}\" does not equal \"2.9.0-no-git\""
-            exit 1
-          fi
-  gh-action-glob:
-    name: action supports glob expansion
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: ./
-        with:
-          dockerfile: "test/**/Dockerfile-glob-*"
-        env:
-          DEBUG: yes

--- a/action.yml
+++ b/action.yml
@@ -48,10 +48,10 @@ runs:
       run: |
         echo "::debug::Downloading Hadolint ${{ inputs.version }}"
         mkdir ${{ github.action_path }}/bin
-        wget -q -O ${{ github.action_path }}/bin/hadolint \
+        curl -L -s -o ${{ github.action_path }}/bin/hadolint \
           "https://github.com/hadolint/hadolint/releases/download/v${{ inputs.version }}/hadolint-Linux-x86_64"
         chmod +x ${{ github.action_path }}/bin/hadolint
-        echo "${{ github.action_path }}/bin" >> $GITHUB_PATH
+        echo "${{ github.action_path }}/bin" >> "${GITHUB_PATH}"
     - name: Invoke hadolint.sh
       id: run
       shell: bash


### PR DESCRIPTION
1. Split action (read: e2e) tests into its own file
2. Refactor how shfmt is downloaded - renovatebot should pick it up now
3. Same as above but for bash_unit