### PR TITLE
fix: standardize curl options and make output optional

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,7 @@
     {
       "fileMatch": ["^\\.github/workflows/[^/]+\\.yml$"],
       "matchStrings": [
-        "version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls \"https://github.com/(?<depName>.*?)/releases/download.*",
+        "version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls( -o \\w+)? \"https://github.com/(?<depName>.*?)/releases/download.*",
         "https://github\\.com/(?<depName>.*?)/archive/refs/tags/(?<currentValue>.*?)\\.tar\\.gz"
       ],
       "datasourceTemplate": "github-releases",

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,6 +67,6 @@ jobs:
       - name: Install shfmt
         env:
           version: "3.5.1"
-        run: curl -L -s -o shfmt "https://github.com/mvdan/sh/releases/download/v${{ env.version }}/shfmt_v${{ env.version }}_linux_amd64" && chmod +x shfmt && sudo mv shfmt /usr/local/bin
+        run: curl -Ls -o shfmt "https://github.com/mvdan/sh/releases/download/v${{ env.version }}/shfmt_v${{ env.version }}_linux_amd64" && chmod +x shfmt && sudo mv shfmt /usr/local/bin
       - name: Lint shell scripts
         run: shfmt -i 2 -d hadolint.sh lib/*.sh test/*.sh


### PR DESCRIPTION
shfmt is the only tool that currently outputs differently as part of the renovate version matching pattern - tell it that it is optional.