### PR TITLE
feat: update README via renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,10 @@
     {
       "matchManagers": ["github-actions"],
       "commitMessageTopic": "{{depName}}"
+    },
+    {
+      "matchPackagePatterns": ["hadolint"],
+      "commitMessageTopic": "hadolint"
     }
   ],
   "regexManagers": [
@@ -36,8 +40,11 @@
       "datasourceTemplate": "github-releases"
     },
     {
-      "fileMatch": ["^action\\.yml$"],
-      "matchStrings": ["version:\\s+default: (?<currentValue>.*?)\\n"],
+      "fileMatch": ["^action\\.yml$", "^README\\.md$"],
+      "matchStrings": [
+        "version:\\s+default: (?<currentValue>.*?)\\n",
+        "version\\s+\\|\\s`(?<currentValue>.*?)`"
+      ],
       "depNameTemplate": "hadolint/hadolint",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"


### PR DESCRIPTION
Renovate now updates both the action as well as README as part of bumping the dependency. Also, make the topic more human readable.