### PR TITLE
fix: don't annotate e2e tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -5,7 +5,7 @@ on:
       - "**.sh"
       - "test/**"
       - "action.yml"
-      - ".github/workflows/test.yml"
+      - ".github/workflows/test-e2e.yml"
 
 jobs:
   gh-action-default:
@@ -40,3 +40,4 @@ jobs:
       - uses: ./
         with:
           dockerfile: "test/**/Dockerfile-glob-*"
+          annotate: false


### PR DESCRIPTION
This creates unnecessary noise for the glob e2e test across all PRs. Also, update the action path to cover `$self`.