### PR TITLE
chore: switch to majors for stable actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
     name: Actionlint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
       - name: Install Actionlint
         env:
           version: "1.6.25"
@@ -53,10 +53,10 @@ jobs:
     runs-on: ubuntu-22.04
     name: Prettier
     steps:
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/setup-node@v3.6.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "18.11.0"
+          node-version: "20"
       - name: Install prettier
         run: npm install -g prettier
       - name: Run prettier
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Shellcheck
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
       - name: Install Shellcheck
         env:
           version: "0.9.0"
@@ -78,7 +78,7 @@ jobs:
     name: Shfmt
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
       - name: Install shfmt
         env:
           version: "3.7.0"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -12,7 +12,7 @@ jobs:
     name: Action validates dockerfiles
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
       - uses: ./
         with:
           dockerfile: test/fixtures/Dockerfile-valid
@@ -20,7 +20,7 @@ jobs:
     name: Action supports custom version
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
       - uses: ./
         id: check
         with:
@@ -36,7 +36,7 @@ jobs:
     name: Action supports glob expansion
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
       - uses: ./
         with:
           dockerfile: "test/**/Dockerfile-glob-*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Bash unit tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3
       - name: Get Hadolint version
         # yq is like jq for yaml
         # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#tools


### PR DESCRIPTION
This way I don't have to manage updates as frequent.