### PR TITLE
fix: don't download hadolint twice

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Verify shell scripts
         run: |
           echo "::add-matcher::.github/matcher-shellcheck.json"
-          shellcheck -f gcc -S warning hadolint.sh lib/*.sh test/*.sh
+          shellcheck -f gcc -S warning hadolint.sh install.sh lib/*.sh test/*.sh
   shfmt:
     name: Shfmt
     runs-on: ubuntu-22.04
@@ -84,4 +84,4 @@ jobs:
           version: "3.7.0"
         run: curl -Ls -o shfmt "https://github.com/mvdan/sh/releases/download/v${{ env.version }}/shfmt_v${{ env.version }}_linux_amd64" && chmod +x shfmt && sudo mv shfmt /usr/local/bin
       - name: Lint shell scripts
-        run: shfmt -i 2 -d hadolint.sh lib/*.sh test/*.sh
+        run: shfmt -i 2 -d hadolint.sh install.sh lib/*.sh test/*.sh

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -32,6 +32,7 @@ jobs:
             echo "::error::Version mismatch: \"${{ steps.check.outputs.hadolint_version }}\" does not equal \"2.9.0-no-git\""
             exit 1
           fi
+
   gh-action-glob:
     name: Action supports glob expansion
     runs-on: ubuntu-22.04
@@ -41,3 +42,28 @@ jobs:
         with:
           dockerfile: "test/**/Dockerfile-glob-*"
           annotate: false
+  # https://github.com/jbergstroem/hadolint-gh-action/issues/134
+  gh-action-multiple-invocations:
+    name: Action supports multiple invocations in a job
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      # Download and run default version
+      - uses: ./
+        with:
+          dockerfile: test/fixtures/Dockerfile-valid
+      # Download and run custom version
+      - uses: ./
+        with:
+          dockerfile: test/fixtures/Dockerfile-valid
+          version: 2.11.0
+      # Redownload if binary is broken
+      - run: chmod -x /usr/local/bin/hadolint
+      - uses: ./
+        with:
+          dockerfile: test/fixtures/Dockerfile-valid
+          version: 2.11.0
+      # Download and run default version again
+      - uses: ./
+        with:
+          dockerfile: test/fixtures/Dockerfile-valid

--- a/action.yml
+++ b/action.yml
@@ -45,13 +45,10 @@ runs:
   steps:
     - name: Download hadolint and make it available in path
       shell: bash
-      run: |
-        echo "::debug::Downloading Hadolint ${{ inputs.version }}"
-        mkdir ${{ github.action_path }}/bin
-        curl -L -s -o ${{ github.action_path }}/bin/hadolint \
-          "https://github.com/hadolint/hadolint/releases/download/v${{ inputs.version }}/hadolint-Linux-x86_64"
-        chmod +x ${{ github.action_path }}/bin/hadolint
-        echo "${{ github.action_path }}/bin" >> "${GITHUB_PATH}"
+      env:
+        version: ${{ inputs.version }}
+      run: ${{ github.action_path }}/install.sh
+
     - name: Invoke hadolint.sh
       id: run
       shell: bash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+CI=${GITHUB_ACTIONS:-}
+
+[[ -n "${DEBUG}" ]] && set -x
+set -euo pipefail
+shopt -s nullglob globstar
+
+[[ -z ${CI} ]] && echo "Will only run in Github Actions" && exit 1
+
+VERSION=${version:-}
+
+DOWNLOAD="false"
+# Check if hadolint is installed and compare versions to decide
+# if we should download a new version
+if [ -x "$(command -v hadolint)" ]; then
+  INSTALLED_VERSION=$(hadolint --version | cut -d " " -f 4 2>&1)
+  echo "::debug::Found existing Hadolint version: ${INSTALLED_VERSION}"
+  if [ "${INSTALLED_VERSION}" != "${VERSION}" ]; then
+    echo "::info::Hadolint version (${INSTALLED_VERSION}) does not match requested version (${VERSION})"
+    DOWNLOAD="true"
+  fi
+else
+  DOWNLOAD="true"
+fi
+
+# Download hadolint if necessary
+if [ "${DOWNLOAD}" == "true" ]; then
+  echo "::debug::Downloading Hadolint ${VERSION}"
+  # https://github.com/actions/runner-images/issues/3727
+  # /usr/local/bin exists and is writable by any user
+  curl -s -L --fail -w 1 -o /tmp/hadolint \
+    "https://github.com/hadolint/hadolint/releases/download/v${VERSION}/hadolint-Linux-x86_64" ||
+    (echo "::error::Hadolint (version: ${VERSION}) could not be found. Exiting." && exit 1)
+  mv /tmp/hadolint /usr/local/bin/hadolint
+  chmod +x /usr/local/bin/hadolint
+fi
+
+echo "::debug:: $(hadolint --version | cut -d " " -f 4 2>&1) installed successfully"


### PR DESCRIPTION
Problem
When one wants to use hadolint-gh-action multiple times, an error is raised because the bin directory already exists, see https://github.com/jbergstroem/hadolint-gh-action/issues/134

Solution
Use option -p of mkdir

Fixes #134