### PR TITLE
chore: ignore hadolint in grouped updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,18 +38,12 @@
 			"matchPackageNames": ["shellcheck"],
 			"commitMessageTopic": "shellcheck"
 		},
-    {
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "matchPackageNames": [
-        "*",
-        "!/hadolint/"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ]
-    }
+		{
+			"groupName": "all non-major dependencies",
+			"groupSlug": "all-minor-patch",
+			"matchPackageNames": ["*", "!/hadolint/"],
+			"matchUpdateTypes": ["minor", "patch"]
+		}
 	],
 	"customManagers": [
 		{


### PR DESCRIPTION
Rewrite the `:group:allNonMajor` rule by excluding hadolint.

Fixes: https://github.com/jbergstroem/hadolint-gh-action/issues/170 