### PR TITLE
fix(renovate): remove glob from matchpackagenames

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,7 +41,7 @@
     {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "matchPackageNames": ["*", "!/hadolint/"],
+      "matchPackageNames": ["!/hadolint/"],
       "matchUpdateTypes": ["minor", "patch"]
     }
   ],


### PR DESCRIPTION
Rely on the negation pattern alone — Renovate treats a standalone negative pattern as "match everything except this"